### PR TITLE
Fixed: Adding and removing priority queues.

### DIFF
--- a/src/test/java/lbmq/LinkedBlockingMultiQueueTest.java
+++ b/src/test/java/lbmq/LinkedBlockingMultiQueueTest.java
@@ -1465,6 +1465,46 @@ public class LinkedBlockingMultiQueueTest extends TestCase {
         assertEquals(0, q.totalSize());
     }
 
+    @Test
+    public void testRemoveQueueOfTheSamePriorityDecrementsNextSubQueuePointer() {
+        LinkedBlockingMultiQueue<QueueKey, Integer> q = new LinkedBlockingMultiQueue<>();
+        q.addSubQueue(QueueKey.A, 0);
+        q.addSubQueue(QueueKey.B, 0);
+
+        q.getSubQueue(QueueKey.A).offer(1);
+        q.getSubQueue(QueueKey.B).offer(2);
+
+        Integer firstPoll = q.poll();
+        q.removeSubQueue(QueueKey.A);
+        Integer secondPoll = q.poll();
+
+        assertEquals(1, (long) firstPoll);
+        assertEquals(2, (long) secondPoll);
+    }
+
+    @Test
+    public void testThatPriorityGroupIsRemovedWhenItDoesNotContainAnySubQueue() {
+        LinkedBlockingMultiQueue<QueueKey, Integer> q = new LinkedBlockingMultiQueue<>();
+        q.addSubQueue(QueueKey.A, 0);
+        q.addSubQueue(QueueKey.B, 1);
+
+        q.getSubQueue(QueueKey.B).offer(2);
+
+        q.removeSubQueue(QueueKey.A);
+
+        Integer poll = q.poll();
+
+        assertEquals(2, (long) poll);
+    }
+
+    @Test
+    public void testAddPrioritySubQueueWhenLowerPriorityQueueExists() {
+        LinkedBlockingMultiQueue<QueueKey, Integer> q = new LinkedBlockingMultiQueue<>();
+        q.addSubQueue(QueueKey.A, 1);
+        q.addSubQueue(QueueKey.B, 0);
+        assertEquals(2, q.getPriorityGroupsCount());
+    }
+
     void checkEmpty(LinkedBlockingMultiQueue<?, ?> q) {
         try {
             assertTrue(q.isEmpty());


### PR DESCRIPTION
1. removeQueue - When removing a subqueue of the same priority, the "round robin pointer to the next subqueue" went index out of bound. The check wast there but we have to remove the subqueue first.
2. addSubQueue - the subqueue was added multiple times. Also, stop the loop after adding an item - without it you get ConcurrentModificationException
3. do not leave a priority subqueue empty - otherwise you'll get "java.lang.IndexOutOfBoundsException: Index: 0, Size: 0" when calling getNextSubQueue