### PR TITLE
Allow to choose a different queue-selection algorithm

### DIFF
--- a/src/main/java/lbmq/DefaultSubQueueSelection.java
+++ b/src/main/java/lbmq/DefaultSubQueueSelection.java
@@ -1,0 +1,47 @@
+/*
+ * $Id$
+ *
+ * Copyright (c) 2018 AspectWorks, spol. s r.o.
+ */
+package lbmq;
+
+import java.util.ArrayList;
+
+/**
+ * Chooses the next queue to be used from the highest priority priority group.
+ * If no queue is found it searches the lower priority groups and so on until
+ * it finds a queue.
+ */
+public class DefaultSubQueueSelection<K, E> implements LinkedBlockingMultiQueue.SubQueueSelection<K, E> {
+
+    private ArrayList<LinkedBlockingMultiQueue<K, E>.PriorityGroup> priorityGroups;
+
+    @Override
+    public LinkedBlockingMultiQueue.SubQueue getNext() {
+        for (int i = 0; i < priorityGroups.size(); i++) {
+            LinkedBlockingMultiQueue.SubQueue subQueue = priorityGroups.get(i).getNextSubQueue();
+            if (subQueue != null) {
+                return subQueue;
+            }
+        }
+        return null;
+    }
+
+    @Override
+    public E peek() {
+        // assert takeLock.isHeldByCurrentThread();
+        for (int i = 0; i < priorityGroups.size(); i++) {
+            E dequed = (E) priorityGroups.get(i).peek();
+            if (dequed != null) {
+                return dequed;
+            }
+        }
+        return null;
+    }
+
+    @Override
+    public void setPriorityGroups(ArrayList<LinkedBlockingMultiQueue<K, E>.PriorityGroup> priorityGroups) {
+        this.priorityGroups = priorityGroups;
+    }
+
+}


### PR DESCRIPTION
Currently, the next queue to be used is chosen based on priority. LBMQ uses round-robin on the highest priority group of queues and chooses one of them. This effectively blocks lower priority queues.

That does not suit my needs. I need LBMQ to use higher priority queues most of the time but allow lower priority queues be used from time to time.

I propose a change where the queue-selection algorithm is hidden behind an interface so that I can provide my own implementation. LBMQ behaves exactly the same as it was before this change - it just adds and uses a new interface. The custom implementation is not intended to be part of the LBMQ as it is specific to my needs.

Let me know what you think. 
