### PR TITLE
SubQueue.enable/disable operations should be idempotent

### DIFF
--- a/src/main/java/lbmq/LinkedBlockingMultiQueue.java
+++ b/src/main/java/lbmq/LinkedBlockingMultiQueue.java
@@ -511,6 +511,10 @@ public class LinkedBlockingMultiQueue<K, E> extends AbstractPollable<E> {
     public void enable(boolean status) {
       fullyLock();
       try {
+        boolean notChanged = status == enabled;
+        if(notChanged){
+          return;
+        }
         enabled = status;
         if (status) {
           // potentially unblock waiting polls

--- a/src/test/java/lbmq/LinkedBlockingMultiQueueTest.java
+++ b/src/test/java/lbmq/LinkedBlockingMultiQueueTest.java
@@ -1371,6 +1371,47 @@ public class LinkedBlockingMultiQueueTest extends TestCase {
     assertEquals(2, q.getPriorityGroupsCount());
   }
 
+  /** {@link lbmq.LinkedBlockingMultiQueue.SubQueue#enable(boolean)} must be idempotent */
+  @Test
+  public void testThatTotalSizeMustNotChangeEnablingAlreadyEnabledQueues(){
+    final LinkedBlockingMultiQueue<QueueKey, Integer> subject = new LinkedBlockingMultiQueue<>();
+    subject.addSubQueue(QueueKey.A, 0);
+    final LinkedBlockingMultiQueue.SubQueue subQueue = subject.getSubQueue(QueueKey.A);
+    subQueue.add(100);
+
+    assertEquals(1, subQueue.size());
+    assertEquals(1, subject.totalSize());
+
+    subQueue.enable(true);
+
+    assertEquals(1, subQueue.size());
+    assertEquals(1, subject.totalSize());
+
+  }
+
+  /** {@link lbmq.LinkedBlockingMultiQueue.SubQueue#enable(boolean)} must be idempotent */
+  @Test
+  public void testThatTotalSizeMustNotChangeDisablingAlreadyDisabledQueues(){
+    final LinkedBlockingMultiQueue<QueueKey, Integer> subject = new LinkedBlockingMultiQueue<>();
+    subject.addSubQueue(QueueKey.A, 0);
+    final LinkedBlockingMultiQueue.SubQueue subQueue = subject.getSubQueue(QueueKey.A);
+    subQueue.add(100);
+
+    assertTrue(subQueue.isEnabled());
+    assertEquals(1, subQueue.size());
+    assertEquals(1, subject.totalSize());
+
+    subQueue.enable(false);
+
+    assertEquals(1, subQueue.size());
+    assertEquals(0, subject.totalSize());
+
+    subQueue.enable(false);
+
+    assertEquals(1, subQueue.size());
+    assertEquals(0, subject.totalSize());
+  }
+
   void checkEmpty(LinkedBlockingMultiQueue<?, ?> q) {
     try {
       assertTrue(q.isEmpty());


### PR DESCRIPTION
Enabling already enabled queues or disabling already disabled queues computed a wrong MultiQueue totalSize causing NullPointer on take/poll operations